### PR TITLE
[Day-7]: Assignments

### DIFF
--- a/day7/main.go
+++ b/day7/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+var mg sync.Mutex
+
+func isEven(n int) bool {
+	return n%2 == 0
+}
+
+func main() {
+	n := 0
+
+	go func() {
+		mg.Lock()
+		nIsEven := isEven(n)
+		time.Sleep(5 * time.Millisecond)
+		if nIsEven {
+			fmt.Println(n, " is even")
+			return
+		}
+		fmt.Println(n, "is odd")
+		mg.Unlock()
+	}()
+
+	go func() {
+		mg.Lock()
+		n++
+		mg.Unlock()
+	}()
+
+	// just waiting for the goroutines to finish before exiting
+	time.Sleep(time.Second)
+}


### PR DESCRIPTION
Assignment:
In the below code snippet concurrent goroutines execution corrupts a piece of data by
accessing it simultaneously it leads in raise condition.
https://go.dev/play/p/SmLMf8hZQzs
output when you run this : 1 is Even (may vary when you run multiple times)

Update the given code to print the correct output.
output once code is corrected: 0 is Even

package main

import (
	"fmt"
	"time"
)

func isEven(n int) bool {
	return n%2 == 0
}

func main() {
	n := 0

	go func() {
		nIsEven := isEven(n)
		time.Sleep(5 * time.Millisecond)
		if nIsEven {
			fmt.Println(n, " is even")
			return
		}
		fmt.Println(n, "is odd")
	}()

	go func() {
		n++
	}()

	// just waiting for the goroutines to finish before exiting
	time.Sleep(time.Second)
}
